### PR TITLE
Fix can not view any in Chinese language.

### DIFF
--- a/FilteredOutputWindowVSX/FilteredOutputWindowVSX/ViewModels/FilteredOutputWindowViewModel.cs
+++ b/FilteredOutputWindowVSX/FilteredOutputWindowVSX/ViewModels/FilteredOutputWindowViewModel.cs
@@ -43,7 +43,15 @@ namespace FilteredOutputWindowVSX
             FilterMode = (FilteringMode)Properties.Settings.Default.FilterMode;
             _documentEvents.PaneUpdated += (e) =>
             {
-                if (e.Name != "Debug") return;
+                // See [IDE GUID](https://docs.microsoft.com/en-us/visualstudio/extensibility/ide-guids?view=vs-2017 )
+                const string debugPane = "{FC076020-078A-11D1-A7DF-00A0C9110051}";
+                if (e.Guid != debugPane)
+                {
+                    return;
+                }
+                // In Chinese we call the Debug as 调试
+                // That is why I can not view any.
+                //if (e.Name != "Debug") return;
                 _currentText = GetPaneText(e);
                 UpdateOutput();
             };


### PR DESCRIPTION
I write a blog to tell to my friends there is a good tool to filter the window. 

Blog: [VisualStudio 扩展开发 获得输出窗口内容](https://lindexi.oschina.io/lindexi/post/VisualStudio-%E6%89%A9%E5%B1%95%E5%BC%80%E5%8F%91-%E8%8E%B7%E5%BE%97%E8%BE%93%E5%87%BA%E7%AA%97%E5%8F%A3%E5%86%85%E5%AE%B9.html )

![image](https://user-images.githubusercontent.com/16054566/52172027-583ba580-27a2-11e9-96ca-ffdd17c91c08.png)

But my friends tell me that they can not view any and I debug the tool and find the tool use pane.Name to filter the window.

In Chinese, we call the Debug as 调试 that is why they can not view.

![image](https://user-images.githubusercontent.com/16054566/52172013-21658f80-27a2-11e9-964f-b99150a67c87.png)


